### PR TITLE
build: add justfile for mkdocs tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,18 @@
+# Use bash for all recipes.
+set shell := ["bash", "-cu"]
+
+# Show available recipes when running plain `just`.
+default:
+  @just --list
+
+# Build the MkDocs site into `site/`.
+build:
+  uv run --no-sync mkdocs build
+
+# Start local docs server with live reload.
+serve:
+  uv run --no-sync mkdocs serve
+
+# Remove generated build output.
+clean:
+  rm -rf site


### PR DESCRIPTION
## Summary
- add a new justfile
- include build, serve, and clean recipes for MkDocs workflows
- make plain just show recipe list via default

## Verification
- just --list
- uv run --no-sync mkdocs build